### PR TITLE
Arch Linux ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ sudo apt-get install wiringpi
 cd Downloads
 git clone git://github.com/rricharz/pi-top-install
 cd pi-top-install
-chmod +x install*
 ```
 
 Make sure that **spi** is turned on in *Menu/Preferences/Raspberry Pi Configuration/Interfaces*.
@@ -75,12 +74,12 @@ sudo apt-get dist-upgrade
 
 To install 2 (brightness):
 ```
-./install-brightness
+sudo ./install-brightness
 ```
 
 To install 3 (automatic poweroff)
 ```
-./install-poweroff
+sudo ./install-poweroff
 ```
 
 Your new software will work after the next bootup.

--- a/install-brightness
+++ b/install-brightness
@@ -1,14 +1,16 @@
-# install brightness and brightness.py in /home/pi/bin
+# install brightness
+
+DIR=/usr/local/bin
 
 # check if the install script is run by the 'pi' user
-if [ `whoami` != pi ]; then
-        echo "Please run as 'pi' user"
+if [ `whoami` != root ]; then
+        echo "Please run as 'root' user"
         exit 1
 fi
 
-# create /home/pi/bin directory, if it does not exist
-[ ! -d /home/pi/bin  ] && mkdir /home/pi/bin
+# create the directory, if it does not exist
+[ ! -d $DIR  ] && mkdir $DIR
 
-# copy the file to /home/pi/bin, make it executable
-cp brightness /home/pi/bin
-chmod +x /home/pi/bin/brightness
+# copy the file, make it executable
+cp brightness $DIR
+chmod +x $DIR/brightness

--- a/install-poweroff
+++ b/install-poweroff
@@ -1,22 +1,24 @@
 # install automatic power off
 
-# check if the install script is run by the 'pi' user
-if [ `whoami` != pi ]; then
-        echo "Please run as 'pi' user"
+DIR=/usr/local/bin
+SYSTEMD_DIR=/etc/systemd/system
+
+# check if the install script is run by the 'root' user
+if [ `whoami` != root ]; then
+        echo "Please run as 'root' user"
         exit 1
 fi
 
-# create /opt/pi-top directory, if it does not exist
-[ ! -d /opt/pi-top  ] && sudo mkdir /opt/pi-top
+# create directory, if it does not exist
+[ ! -d $DIR  ] && mkdir -p $DIR
 
-# copy poweroff to/opt/pi-top
-sudo cp poweroff /opt/pi-top
-sudo chmod 755 /opt/pi-top/poweroff
+# copy poweroff
+cp poweroff $DIR
+chmod 755 $DIR/poweroff
 
 # turn off pt-poweroff.service, if running (upgrade instead of installation)
-sudo systemctl disable pt-poweroff.service
+systemctl disable pt-poweroff.service
 
 # install pt-poweroff service
-sudo cp pt-poweroff.service /lib/systemd/system
-cd /lib/systemd/system
-sudo systemctl enable pt-poweroff.service
+cp pt-poweroff.service $SYSTEMD_DIR
+systemctl enable pt-poweroff.service

--- a/pt-poweroff.service
+++ b/pt-poweroff.service
@@ -5,7 +5,7 @@ Before=umount.target
 
 [Service]
 Type=oneshot
-ExecStart=/opt/pi-top/poweroff
+ExecStart=/usr/local/bin/poweroff
 
 [Install]
 WantedBy=halt.target poweroff.target


### PR DESCRIPTION
Thanks for the repo - I used it successfully with my pi-top CEED running Arch Linux ARM. I updated the installation scripts to put the executable in one common path: `/usr/local/bin`. I don't see a reason, why the brightness script should be installed to `/home/pi/bin` and thus for this user only. Also, I'm not a big fan of installing software to /opt except for proprietary/binary tools.
The changes mean that both install scripts require root permissions, so I updated the README too.
